### PR TITLE
(#3) Fix NotSupportedException while loading external dlls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,16 +5,11 @@ root = true
 end_of_line = CRLF
 
 ; 4-column tab indentation
-[*.cs]
+[*.{cs,xaml}]
 indent_style = space
 indent_size = 4
 
 ; 4-column tab indentation
-[*.xaml]
+[*.{xml,config}]
 indent_style = space
-indent_size = 4
-
-; 4-column tab indentation
-[*.xml]
-indent_style = space
-indent_size = 4
+indent_size = 2

--- a/src/Kaxaml/Kaxaml.csproj
+++ b/src/Kaxaml/Kaxaml.csproj
@@ -311,7 +311,9 @@
     </EmbeddedResource>
     <Resource Include="Fonts\Miramo.ttf" />
     <Resource Include="Fonts\Miramob.ttf" />
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/src/Kaxaml/Views/PluginView.xaml.cs
+++ b/src/Kaxaml/Views/PluginView.xaml.cs
@@ -73,12 +73,12 @@ namespace Kaxaml.Views
             // load each of the plugins in the directory
             foreach (FileInfo f in d.GetFiles("*.dll"))
             {
-                Assembly asm = Assembly.LoadFile(f.FullName);
+                var bytes = File.ReadAllBytes(f.FullName);
+                Assembly asm = Assembly.Load(bytes);
                 Type[] types = asm.GetExportedTypes();
                 foreach (Type typ in types)
                 {
                     var a = typ.GetCustomAttributes(typeof(PluginAttribute), false).Cast<PluginAttribute>().SingleOrDefault();
-
                     if (a != null && typeof(UserControl).IsAssignableFrom(typ))
                     {
                         Plugin p = new Plugin()

--- a/src/Kaxaml/app.config
+++ b/src/Kaxaml/app.config
@@ -83,6 +83,9 @@
       </setting>
     </Kaxaml.Properties.Settings>
   </userSettings>
+  <runtime>
+    <loadFromRemoteSources enabled="true" />
+  </runtime>
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
   </startup>

--- a/src/KaxamlPlugins/KaxamlPlugins.csproj
+++ b/src/KaxamlPlugins/KaxamlPlugins.csproj
@@ -49,7 +49,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
@@ -57,7 +57,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <Optimize>true</Optimize>
-    <OutputPath>..\bin\Release\</OutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
@@ -69,19 +69,10 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xaml" />
-    <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="UIAutomationProvider" />
-    <Reference Include="UIAutomationTypes" />
-    <Reference Include="ReachFramework" />
-    <Reference Include="System.Printing" />
-    <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.IdentityModel" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Controls\ColorPicker.cs" />


### PR DESCRIPTION
Use loadFromRemoteSources to prevent this exception. Get more info here https://blogs.msdn.microsoft.com/shawnfa/2009/06/08/more-implicit-uses-of-cas-policy-loadfromremotesources/

Fixes #3 
Relates to #3 